### PR TITLE
Bug 1212873 - Compute the 95% confidence interval for mean

### DIFF
--- a/lib/phases/phase.js
+++ b/lib/phases/phase.js
@@ -505,15 +505,17 @@ Phase.prototype.calculateStats = function() {
         .forEach(function(key) {
           var values = contextResults[key];
           var mean = stats.mean(values);
+          var stdev = stats.stdev(values);
 
           statistics[contextKey].push({
             Metric: key,
             Mean: mean,
             Median: stats.median(values),
             Min: Math.min.apply(Math, values),
+            '95th Perc.': stats.percentile(values, 0.95) || mean,
             Max: Math.max.apply(Math, values),
-            StdDev: stats.stdev(values),
-            p95: stats.percentile(values, 0.95) || mean
+            StdDev: stdev,
+            '95% Bound': mean + (1.96 * stdev / Math.sqrt(values.length)),
           });
         });
     });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1212873
